### PR TITLE
make chartreleaser skip existing versions 

### DIFF
--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -32,3 +32,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.4.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true

--- a/charts/sigscalr/Chart.yaml
+++ b/charts/sigscalr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Release:

- [ ] To create a release, I will create a PR from to `main` with an incremented version in Chart.yaml
    - Internally, we rely on [chart-releaser](https://github.com/helm/chart-releaser-action) to automatically update the index.yaml on the `gh-pages` branch on version updates.
- [ ] I will **squash and merge** this branch to `main`